### PR TITLE
feat(watch): 实现 watch 模式以自动检查练习

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,12 @@ name = "movelings"
 version = "0.1.0"
 edition = "2021"
 description = "Interactive Move programming language exercises"
-authors = ["Your Name <your.email@example.com>"]
 
 [[bin]]
 name = "movelings"
 path = "src/main.rs"
 
 [dependencies]
+clap = { version = "4.4.8", features = ["derive"] }
+colored = "2.0.0"
+notify = "6.1.1"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Movelings 是一个交互式的 Move 语言学习工具，包含：
 | --------------------------- | ------------------ | --------------------------- |
 | `cargo run`               | 显示主菜单和概览   | -                           |
 | `cargo run <练习名>`      | 检查特定练习       | `cargo run 00_intro`      |
+| `cargo run watch`         | 监视文件变化并自动检查 | -                           |
 | `cargo run list`          | 列出所有练习和进度 | -                           |
 | `cargo run hint <练习名>` | 获取练习提示       | `cargo run hint 00_intro` |
 | `cargo run progress`      | 查看详细进度报告   | -                           |
@@ -99,6 +100,12 @@ Movelings 是一个交互式的 Move 语言学习工具，包含：
    ```bash
    cargo run list
    ```
+7. **使用监视模式**（推荐）：
+
+  ```bash
+  cargo run watch
+  ```
+  此命令会自动检查第一个未完成的练习，并在你修改并保存任何练习文件时自动重新运行测试。
 
 ### 练习结构
 


### PR DESCRIPTION
为 movelings 添加了一个 'watch' 模式。

此功能会监视 'exercises/' 目录中的文件更改。当一个练习的 .move 源文件被修改时，它会自动重新运行该练习的检查。

这极大地改善了开发体验，用户不再需要在每次修改后手动执行命令。

该功能使用 `notify` crate 来实现文件系统监视。