### PR TITLE
feat: 支持通过简短的前缀查找运行练习

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -84,12 +84,12 @@ pub fn check_exercise(name: &str) -> bool {
     }
 }
 
-pub fn show_hint(exercise: &str) {
+pub fn show_hint(exercise: &str) -> bool {
     println!();
     println!("{} Hints for exercise '{}':", "💡".yellow(), exercise.bold());
-    
+
     let hints = extract_hints_from_exercise(exercise);
-    
+
     if hints.is_empty() {
         show_default_hints();
     } else {
@@ -97,10 +97,11 @@ pub fn show_hint(exercise: &str) {
             println!("  {}. {}", i + 1, hint.italic());
         }
     }
-    
+
     println!();
     println!("{} Exercise file location:", "📝".blue());
     println!("   {}", format!("exercises/{}/sources/", exercise).cyan());
+    true
 }
 
 pub fn reset_progress() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,22 +5,48 @@ mod utils;
 use clap::Parser;
 use cli::{Cli, Commands};
 use handlers::*;
-
+use crate::utils::find_exercise_by_prefix;
+ 
 fn main() {
     let cli = Cli::parse();
 
+    let command_handler = |name: &str, action: fn(&str) -> bool| {
+        match find_exercise_by_prefix(name) {
+            Ok(exercise_name) => {
+                action(&exercise_name);
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
+    };
+
+    let hint_handler = |name: &str| {
+        match find_exercise_by_prefix(name) {
+            Ok(exercise_name) => {
+                show_hint(&exercise_name);
+                true
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
+    };
+
     match cli.command {
         Some(Commands::List) => list_exercises(),
-        Some(Commands::Run { name }) => {
-            check_exercise(&name);
+        Some(Commands::Run { name }) => command_handler(&name, check_exercise),
+        Some(Commands::Hint { name }) => {
+            hint_handler(&name);
         },
-        Some(Commands::Hint { name }) => show_hint(&name),
         Some(Commands::Reset) => reset_progress(),
         Some(Commands::Progress) => show_progress(),
         Some(Commands::Watch) => watch_mode(),
         Some(Commands::Exercise(args)) => {
             if let Some(exercise_name) = args.first() {
-                check_exercise(exercise_name);
+                command_handler(exercise_name, check_exercise);
             } else {
                 eprintln!("Error: No exercise name provided");
                 std::process::exit(1);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -150,3 +150,19 @@ pub fn find_exercise_name_from_path(path: &Path) -> Option<String> {
         .and_then(|s| s.to_str())
         .map(|s| s.to_string())
 }
+pub fn find_exercise_by_prefix(prefix: &str) -> Result<String, String> {
+    let exercises = get_exercises();
+    let mut matches: Vec<_> = exercises
+        .iter()
+        .filter(|e| e.starts_with(prefix))
+        .collect();
+
+    match matches.len() {
+        1 => Ok(matches.remove(0).clone()),
+        0 => Err(format!("No exercise found with prefix '{}'", prefix)),
+        _ => Err(format!(
+            "Multiple exercises found with prefix '{}': {:?}",
+            prefix, matches
+        )),
+    }
+}


### PR DESCRIPTION
- 在 `utils.rs` 中新增 `find_exercise_by_prefix` 函数，用于通过简短的前缀（如 "01"）查找完整的练习名称（如 "01_variables"）。
- 修改 `main.rs` 的命令处理逻辑，集成前缀查找功能，提升用户体验。
- 如果前缀匹配到零个或多个练习，将向用户显示明确的错误信息。
- 现在用户可以使用 `movelings run 01` 代替 `movelings run 01_variables` 来运行练习。